### PR TITLE
feat(package): prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "pnpm tsc",
     "test": "node test test/index.js",
     "prettier:check": "pnpm dlx prettier . --check",
-    "prettier:write": "pnpm dlx prettier . --write"
+    "prettier:write": "pnpm dlx prettier . --write",
+    "prepare": "pnpm build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since this is a typescript package it requires to be build before it gets installed. Adding a prepare script means that it can be installed from other sources besides npm (where it is already built) because it will automatically setup the package