### PR TITLE
fix: version not being on client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -27,6 +27,7 @@ export default class Client {
   private validation: ValidationOptions;
   private baseURL: string;
   public readonly cache: MowojangCache;
+  public readonly version: string = VERSION[0];
   public static readonly version: string = VERSION[0];
 
   /**


### PR DESCRIPTION
client isn't exposing it and only static is
static works for pulling the installed version from reborn but since client doesn't have it's own version I cannot compare them